### PR TITLE
add in timestamp (instead of 00:00:00)

### DIFF
--- a/app/views/__init__.py
+++ b/app/views/__init__.py
@@ -99,6 +99,8 @@ class JobRSSView(FlaskView):
         try:
             date = soup.find(text='Posted Date').parent.findNext('span').attrs['title'].split(' ')[0]
             date = datetime.datetime.strptime(date, '%m/%d/%Y')
+            now = datetime.datetime.now()
+            date = date.replace(hour=now.hour, minute=now.minute, second=now.second)
         except:
             date = datetime.datetime.now()
 


### PR DESCRIPTION
## Description

Judd messaged me stating that a Campaign Monitor automation isn't working when the rss feed <pubDate> is has a timestamp of 00:00:00 so I updated it so it isn't 00:00:00 and is the same as what happens if we can't scrape a published date.

## Size and Type of change

- Small Change - 1 person needs to review this

- Bug fix

## How Has This Been Tested?

I tested this locally and made sure the timestamps were no longer 00:00:00

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)